### PR TITLE
updates ember to 2.10 and removes ember-font-awesome

### DIFF
--- a/addon/templates/components/context-menu-item.hbs
+++ b/addon/templates/components/context-menu-item.hbs
@@ -1,7 +1,4 @@
 <span class="context-menu__item__label">
-  {{#if item.icon}}
-    {{fa-icon item.icon class="context-menu__item__icon"}}
-  {{/if}}
   {{item.label}} {{#if amount}}({{amount}}){{/if}}
 </span>
 

--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,9 @@
 {
   "name": "ember-context-menu",
   "dependencies": {
-    "ember": "~2.6.0",
-    "ember-cli-shims": "0.1.1",
+    "ember": "2.10.2",
+    "ember-cli-shims": "0.1.3",
     "ember-cli-test-loader": "0.2.2",
-    "ember-qunit-notifications": "0.1.0",
-    "font-awesome": "^4.7.0"
+    "ember-qunit-notifications": "0.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
     "ember-ajax": "^2.0.1",
-    "ember-cli": "2.6.3",
+    "ember-cli": "2.10.0",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-github-pages": "0.1.2",
@@ -50,8 +50,7 @@
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-sass": "5.5.1",
     "ember-invoke-action": "1.4.0",
-    "ember-font-awesome": "^2.2.0",
-    "ember-wormhole": "0.4.0"
+    "ember-wormhole": "0.5.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/integration/components/context-menu-item-test.js
+++ b/tests/integration/components/context-menu-item-test.js
@@ -195,19 +195,3 @@ test('selection amount only on parent', function(assert) {
   assert.equal($parent[0].innerText.trim(), 'foo', 'shows parent without amount');
   assert.equal($sub[0].innerText.trim(), 'bar (2)', 'shows sub with amount');
 });
-
-test('renders with icons', function(assert) {
-  this.set('item', {
-    label: 'foo',
-    icon: 'search'
-  });
-
-  this.render(hbs`{{context-menu-item item=item}}`);
-
-  let $option = $('li.context-menu__item').eq(0);
-  let $icon   = $option.find('.fa');
-
-  assert.equal($icon.length, 1, 'shows icon');
-  assert.ok($icon.hasClass('fa-search'), 'shows right font-awesome icon');
-  assert.ok($icon.hasClass('context-menu__item__icon'), 'has icon class');
-});


### PR DESCRIPTION
# update to ember 2.10
The changes below get ember-context-menu working, but are not ideal because I had to remove `fa-icon` support. Feel free to close this PR.

### changes
- updates ember, ember-wormhole, ember-cli-shims
- removes ember-font-awesome, font-awesome
- removes icon support from template and tests

### reason for removing font-awesome
```
justin@justin: ember-context-menu master*$ ember s
DEPRECATION: Using the `baseURL` setting is deprecated, use `rootURL` instead.
Path must be a string. Received undefined
TypeError: Path must be a string. Received undefined
    at assertPath (path.js:7:11)
    at Object.join (path.js:1213:7)
    at Class.included (/Users/justin/bx/ember-context-menu/node_modules/ember-font-awesome/index.js:54:23)
    at Class.superWrapper [as included] (/Users/justin/bx/ember-context-menu/node_modules/core-object/lib/assign-properties.js:34:20)
    at /Users/justin/bx/ember-context-menu/node_modules/ember-cli/lib/models/addon.js:254:34
    at Array.map (native)
    at Class.eachAddonInvoke (/Users/justin/bx/ember-context-menu/node_modules/ember-cli/lib/models/addon.js:252:24)
    at Class.included (/Users/justin/bx/ember-context-menu/node_modules/ember-cli/lib/models/addon.js:429:10)
    at Class.superWrapper [as included] (/Users/justin/bx/ember-context-menu/node_modules/core-object/lib/assign-properties.js:34:20)
    at EmberAddon.<anonymous> (/Users/justin/bx/ember-context-menu/node_modules/ember-cli/lib/broccoli/ember-app.js:469:15)
```