### PR TITLE
Adds fastboot compatibility.

### DIFF
--- a/addon/components/context-menu.js
+++ b/addon/components/context-menu.js
@@ -1,10 +1,13 @@
 import layout from '../templates/components/context-menu';
 
+import Ember from 'ember';
 import Component from 'ember-component';
 import service   from 'ember-service/inject';
 import { htmlSafe } from 'ember-string';
 import computed, { alias } from 'ember-computed';
 import get from 'ember-metal/get';
+
+const { on } = Ember;
 
 export default Component.extend({
   layout,
@@ -16,18 +19,13 @@ export default Component.extend({
   selection: alias('contextMenu.selection'),
   details:   alias('contextMenu.details'),
 
-  init() {
-    this._super(...arguments);
-    this.setWormholeTarget();
-  },
-
-  setWormholeTarget() {
+  setWormholeTarget: on('didInsertElement', function() {
     let id = 'wormhole-context-menu';
     let $target = $(`#${id}`);
     if ($target.length === 0) {
       $('body').append(`<div id="${id}"></div>`);
     }
-  },
+  }),
 
   position: computed('contextMenu.position.{left,top}', function() {
     let { left, top } = get(this, 'contextMenu.position') || {};


### PR DESCRIPTION
This pull request makes `ember-context-menu` compatible with `fastboot` by moving the `jQuery` stuff from `init` to the `didInsertElement` lifecycle hook.