### PR TITLE
refactor + pass click event to actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ export default Ember.Component.extend(contextMenuMixin, {
   contextItems: [
     {
       label: 'do something',
-      action() { /* do something */ }
+      action(selection, details, event) { /* do something */ }
     }
   ]
 });

--- a/addon/components/context-menu-item.js
+++ b/addon/components/context-menu-item.js
@@ -13,49 +13,26 @@ export default Component.extend({
 
   classNames: ['context-menu__item'],
   classNameBindings: [
-    '_disabled:context-menu__item--disabled',
+    'isDisabled:context-menu__item--disabled',
     '_isParent:context-menu__item--parent'
   ],
 
+  _amount: computed('_isParent', 'amount', function() {
+    let amount = get(this, 'amount');
+
+    return !get(this, '_isParent') && amount > 1 && amount;
+  }),
+
   _isParent: bool('item.subActions.length'),
 
-  _selection: computed('selection.[]', function() {
-    return [].concat(get(this, 'selection'));
-  }),
-
-  amount: computed('_selection.length', '_isParent', function() {
-    let amount   = get(this, '_selection.length');
-    let isParent = get(this, '_isParent');
-
-    return amount > 1 && !isParent ? amount : null;
-  }),
-
-  _disabled: computed('item.{disabled,action,subActions.length}', '_selection',
-  function() {
-    let item       = get(this, 'item');
-    let disabled   = get(item, 'disabled');
-    let action     = get(item, 'action');
-    let subActions = get(item, 'subActions.length');
-    let selection  = get(this, '_selection');
-
-    if (!action && !subActions) {
-      return true;
-    }
-
-    if (typeof disabled === 'function') {
-      return disabled(selection);
-    }
-
-    return disabled;
+  isDisabled: computed('item.{disabled,action}', 'itemIsDisabled', function() {
+    let item = get(this, 'item');
+    return invokeAction(this, 'itemIsDisabled', item);
   }),
 
   click() {
-    if (!get(this, '_disabled') && !get(this, '_isParent')) {
-      let item      = get(this, 'item');
-      let selection = get(this, '_selection');
-      let details   = get(this, 'details');
-
-      invokeAction(item, 'action', selection, details);
+    if (!get(this, 'isDisabled') && !get(this, '_isParent')) {
+      invokeAction(this, 'clickAction', get(this, 'item'));
     }
   }
 });

--- a/addon/components/context-menu.js
+++ b/addon/components/context-menu.js
@@ -1,9 +1,11 @@
 import layout from '../templates/components/context-menu';
 
+import invokeAction from 'ember-invoke-action';
+
 import Component from 'ember-component';
 import service   from 'ember-service/inject';
 import { htmlSafe } from 'ember-string';
-import computed, { alias } from 'ember-computed';
+import computed, { reads } from 'ember-computed';
 import get from 'ember-metal/get';
 
 export default Component.extend({
@@ -11,11 +13,16 @@ export default Component.extend({
 
   contextMenu: service('context-menu'),
 
-  isActive:   alias('contextMenu.isActive'),
-  renderLeft: alias('contextMenu.renderLeft'),
-  items:      alias('contextMenu.items'),
-  selection:  alias('contextMenu.selection'),
-  details:    alias('contextMenu.details'),
+  isActive:   reads('contextMenu.isActive'),
+  renderLeft: reads('contextMenu.renderLeft'),
+  items:      reads('contextMenu.items'),
+  _selection: reads('contextMenu.selection'),
+  details:    reads('contextMenu.details'),
+  clickEvent: reads('contextMenu.event'),
+
+  selection: computed('_selection.[]', function() {
+    return [].concat(get(this, '_selection'));
+  }),
 
   didInsertElement() {
     this._super(...arguments);
@@ -33,5 +40,34 @@ export default Component.extend({
   position: computed('contextMenu.position.{left,top}', function() {
     let { left, top } = get(this, 'contextMenu.position') || {};
     return htmlSafe(`left: ${left}px; top: ${top}px;`);
+  }),
+
+  itemIsDisabled: computed('selection.[]', 'details', function() {
+    let selection = get(this, 'selection') || [];
+    let details   = get(this, 'details');
+
+    return function(item) {
+      let disabled  = get(item, 'disabled');
+
+      if (!get(item, 'action') && !get(item, 'subActions')) {
+        return true;
+      }
+
+      if (typeof disabled === 'function') {
+        return disabled(selection, details);
+      }
+
+      return disabled;
+    };
+  }),
+
+  clickAction: computed('selection.[]', 'details', function() {
+    let selection = get(this, 'selection');
+    let details   = get(this, 'details');
+    let event     = get(this, 'clickEvent');
+
+    return function(item) {
+      invokeAction(item, 'action', selection, details, event);
+    };
   })
 });

--- a/addon/services/context-menu.js
+++ b/addon/services/context-menu.js
@@ -37,6 +37,7 @@ export default Service.extend({
       top:  clientY
     });
 
+    set(this, 'event',      event);
     set(this, 'items',      items);
     set(this, 'selection',  selection);
     set(this, 'details',    details);

--- a/addon/templates/components/context-menu-item.hbs
+++ b/addon/templates/components/context-menu-item.hbs
@@ -1,14 +1,15 @@
 <span class="context-menu__item__label">
-  {{item.label}} {{#if amount}}({{amount}}){{/if}}
+  {{item.label}} {{#if _amount}}({{_amount}}){{/if}}
 </span>
 
 {{#if item.subActions}}
-  {{#unless _disabled}}
+  {{#unless isDisabled}}
     <ul class="context-menu--sub">
       {{#each item.subActions as |subItem|}}
         {{context-menu-item item=subItem
-                            details=details
-                            selection=selection}}
+                            amount=amount
+                            itemIsDisabled=itemIsDisabled
+                            clickAction=clickAction}}
       {{/each}}
     </ul>
   {{/unless}}

--- a/addon/templates/components/context-menu.hbs
+++ b/addon/templates/components/context-menu.hbs
@@ -4,8 +4,9 @@
       <ul class="context-menu {{if renderLeft "context-menu--left"}}">
         {{#each items as |item|}}
           {{context-menu-item item=item
-                              details=details
-                              selection=selection}}
+                              amount=selection.length
+                              itemIsDisabled=itemIsDisabled
+                              clickAction=clickAction}}
         {{/each}}
       </ul>
     </div>

--- a/tests/dummy/app/components/test-component.js
+++ b/tests/dummy/app/components/test-component.js
@@ -40,7 +40,7 @@ export default Component.extend(contextMenuMixin, {
               label: 'Add',
               subActions: [
                 { label: 'Add 1', action(objects) { increment(objects, 1); } },
-                { label: 'Add 3', action(objects) { increment(objects, 3); } },
+                { label: 'Add 3', disabled: true, action(objects) { increment(objects, 3); } },
                 { label: 'Add 10', action(objects) { increment(objects, 10); } }
               ]
             }

--- a/tests/integration/components/context-menu-test.js
+++ b/tests/integration/components/context-menu-test.js
@@ -63,6 +63,19 @@ function(assert) {
             'renders with left class when on the right of the screen');
 });
 
+test('closes on click anywhere', function(assert) {
+  run(() => contextMenu.activate(e, [1]));
+
+  let $contextMenu = $target.find('.context-menu');
+  assert.equal($contextMenu.length, 1, 'visible on active');
+
+  run(() => $(document.body).click());
+
+  $contextMenu = $target.find('.context-menu');
+  assert.equal(contextMenu.isActive, false, 'isActive is set false on click');
+  assert.equal($contextMenu.length, 0, 'closed on click anywhere');
+});
+
 test('renders with given items', function(assert) {
   run(() => contextMenu.activate(e, [{ label: 'edit' }, { label: 'delete' }]));
 
@@ -77,17 +90,4 @@ test('renders with given items', function(assert) {
   $items = $target.find('.context-menu__item');
   assert.equal($items[0].innerText.trim(), 'edit (2)',
                'renders item with selection amount');
-});
-
-test('closes on click anywhere', function(assert) {
-  run(() => contextMenu.activate(e, [1]));
-
-  let $contextMenu = $target.find('.context-menu');
-  assert.equal($contextMenu.length, 1, 'visible on active');
-
-  run(() => $(document.body).click());
-
-  $contextMenu = $target.find('.context-menu');
-  assert.equal(contextMenu.isActive, false, 'isActive is set false on click');
-  assert.equal($contextMenu.length, 0, 'closed on click anywhere');
 });

--- a/tests/unit/components/context-menu-test.js
+++ b/tests/unit/components/context-menu-test.js
@@ -1,0 +1,74 @@
+import { moduleForComponent, test } from 'ember-qunit';
+
+let subject;
+
+moduleForComponent('context-menu', 'Unit | Component | context-menu', {
+  unit: true,
+
+  beforeEach() {
+    subject = this.subject();
+  }
+});
+
+test('isDisabled() when no action set', function(assert) {
+  let item = { };
+
+  assert.equal(subject.get('itemIsDisabled')(item), true);
+});
+
+test('isDisabled() returns item.disabled', function(assert) {
+  let item = {
+    action() { }
+  };
+
+  assert.notOk(subject.get('itemIsDisabled')(item), 'not disabled when no disabled');
+
+  item.disabled = false;
+  assert.notOk(subject.get('itemIsDisabled')(item), 'not disabled when disabled=false');
+
+  item.disabled = true;
+  assert.ok(subject.get('itemIsDisabled')(item), 'disabled when disabled=true');
+});
+
+test(`isDisabled() depending on selection and details`, function(assert) {
+  assert.expect(3);
+
+  let contextSelection = subject.set('selection', [1, 2]);
+  let contextDetails   = subject.set('details', { foo: 'bar' });
+
+  let item = {
+    label: 'foo',
+    action() { },
+    disabled(selection, details) {
+      assert.deepEqual(selection, contextSelection,
+                       'calls disabled function with selection');
+
+      assert.deepEqual(details, contextDetails,
+                       'calls disabled function with details');
+
+      return true;
+    }
+  };
+
+  assert.equal(subject.get('itemIsDisabled')(item), true);
+});
+
+test(`clickAction() calls item's action with selection and details`,
+function(assert) {
+  assert.expect(3);
+
+  let contextSelection = subject.set('selection', [1, 2]);
+  let contextDetails   = subject.set('details', { foo: 'bar' });
+  let contextEvent     = subject.set('clickEvent', { clientX: 45 });
+
+  let item = {
+    label: 'foo',
+    action(selection, details, event) {
+      assert.deepEqual(selection, contextSelection, 'calls action with selection');
+      assert.deepEqual(details, contextDetails, 'calls action with details');
+      assert.deepEqual(event, contextEvent, 'calls action with click event');
+    }
+  };
+
+  subject.get('clickAction')(item);
+});


### PR DESCRIPTION
Some applications need the position on actions, so now the click event will be passed as third attribute

With that, the logic of calling actions are moved to the context-menu itself, instead of the specific item.